### PR TITLE
Fix textile link

### DIFF
--- a/app/views/blog/archives/_comment_form.html.erb
+++ b/app/views/blog/archives/_comment_form.html.erb
@@ -1,6 +1,6 @@
 <div id="postcomment">
   <h4>Post a Comment</h4>
-  <p>Please use your real name and be respectful. <a href="http://hobix.com/textile/">Textile</a> formatting is supported.</p>
+  <p>Please use your real name and be respectful. <a href="http://redcloth.org/hobix.com/textile/">Textile</a> formatting is supported.</p>
 
 <%= render "shared/alerts" %>
 


### PR DESCRIPTION
I only noticed the other day that this was a broken link and must have been for some time. This updates the textile link to the page that Redcloth has provided as a cache of the original site, which vanished when _why the lucky stiff disappeared.