### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -852,7 +852,7 @@ GEM
     msgpack (1.2.7)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -1005,7 +1005,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.18)
+    yard (0.9.20)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Due to warnings about security exposures it is prudent to update the
nokogiri and yard gems.