### PR TITLE
Fix close alert

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,7 +17,6 @@ const imagePath = (name) => images(name, true)
 
 import 'core-js/stable'
 import 'regenerator-runtime/runtime'
-import '../src/rails.js'
 import '../src/application.js'
 import '../src/application.css'
 import '../src/coderay.css'

--- a/app/javascript/src/application.js
+++ b/app/javascript/src/application.js
@@ -3,11 +3,3 @@ $(document).ready(function() {
     window.location = window.location.href + "#postcomment";
   }
 });
-
-function closeAlert(event){
-  var element = event.target;
-  while (element.nodeName !== "BUTTON"){
-    element = element.parentNode;
-  }
-  element.parentNode.parentNode.removeChild(element.parentNode);
-}

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -4,3 +4,13 @@
     <%= msg %>
   </div>
 <% end %>
+
+<script>
+  function closeAlert(event){
+    var element = event.target;
+    while (element.nodeName !== "BUTTON"){
+      element = element.parentNode;
+    }
+    element.parentNode.parentNode.removeChild(element.parentNode);
+  }
+</script>


### PR DESCRIPTION
Whilst I'm getting used to how JS functions are found via Webpacker, to
enable the close buttons to work, I'm moving the `closeAlert` function to
within a `<script>` tag in the shared view that deals with alert messages.
It's not such a bad place for it.