### PR TITLE
Remove unsupported config

### DIFF
--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,1 +1,0 @@
-Rack::Timeout.timeout = 10 if Rails.env == "production"


### PR DESCRIPTION
Recent deployments have failed with the following message:

`NoMethodError: undefined method `timeout=' for Rack::Timeout:Class`

So, this change removes the config that attempts to use that method.