### PR TITLE
Fix cache store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
   }
   
   # Configure memcachier
-  config.cache_store =  :dalli_store,
+  config.cache_store =  :mem_cache_store,
   (ENV["MEMCACHIER_SERVERS"] || "").split(","),
   { :username => ENV["MEMCACHIER_USERNAME"],
     :password => ENV["MEMCACHIER_PASSWORD"],


### PR DESCRIPTION
This fix is in response to warnings in the log that `:dalli_store` is
deprecated. I already know that it caused problems with attempts to
write to the cache when I deployed my first attempt at an upgrade to
Rails 6.1.