### PR TITLE
Fix Admin UI to enable items to be removed

### DIFF
--- a/app/javascript/src/application.css
+++ b/app/javascript/src/application.css
@@ -49,7 +49,7 @@ a:hover {
   @apply bg-teal-300;
 }
 .btn-form {
-  @apply mt-4 mr-2;
+  @apply mr-2;
 }
 .btn-mini {
   @apply text-sm font-light bg-gray-500 text-white py-1 px-2;
@@ -80,6 +80,10 @@ blockquote cite {
 }
 img {
   @apply inline;
+}
+form.button_to input {
+  border-width: 0;
+  margin: 0;
 }
 form label {
   @apply block text-gray-700 mt-2;

--- a/app/views/admin/achievements/index.html.erb
+++ b/app/views/admin/achievements/index.html.erb
@@ -15,9 +15,9 @@
       <tr>
         <td><%= achievement.rank %></td>
         <td><%= achievement.heading %></td>
-        <td>
-          <%= link_to 'Edit', edit_admin_achievement_path(achievement), :class => "btn btn-mini" %>
-          <%= link_to 'Delete', admin_achievement_path(achievement), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger" %>
+        <td class="form-actions">
+          <%= link_to 'Edit', edit_admin_achievement_path(achievement), :class => "btn btn-mini btn-form" %>
+          <%= button_to 'Delete', admin_achievement_path(achievement), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger btn-form" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -16,9 +16,9 @@
       <tr>
         <td><%= post.published_at.present? ? post.published_at.to_date.to_formatted_s(:rfc822) : '' %></td>
         <td><%= post.title %></td></td><td><%= post.status %></td>
-        <td>
-          <%= link_to 'Edit', edit_admin_blog_post_path(post), :class => "btn btn-mini" %>
-          <%= link_to 'Delete', admin_blog_post_path(post), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger" %></td>
+        <td class="form-actions">
+          <%= link_to 'Edit', edit_admin_blog_post_path(post), :class => "btn btn-mini btn-form" %>
+          <%= button_to 'Delete', admin_blog_post_path(post), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger btn-form"%></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/images/index.html.erb
+++ b/app/views/admin/images/index.html.erb
@@ -15,8 +15,8 @@
       <tr>
         <td><%= image_tag image.picture.url(:thumb) %></td>
         <td><%= link_to image.picture.url, image.picture.url %></td>
-        <td>
-          <%= link_to 'Delete', admin_image_path(image), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger ml-1" %>
+        <td class="form-actions">
+          <%= button_to 'Delete', admin_image_path(image), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger btn-form ml-1" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/testimonials/index.html.erb
+++ b/app/views/admin/testimonials/index.html.erb
@@ -19,9 +19,9 @@
         <td><%= testimonial.provider_name %></td>
         <td><%= testimonial.provider_position %></td>
         <td><%= testimonial.recommendation_year %></td>
-        <td>
-          <%= link_to 'Edit', edit_admin_testimonial_path(testimonial), :class => "btn btn-mini" %>
-          <%= link_to 'Delete', admin_testimonial_path(testimonial), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger" %>
+        <td class="form-actions">
+          <%= link_to 'Edit', edit_admin_testimonial_path(testimonial), :class => "btn btn-mini btn-form" %>
+          <%= button_to 'Delete', admin_testimonial_path(testimonial), :confirm => 'Are you sure?', :method => :delete, :class => "btn btn-mini btn-danger btn-form" %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :achievements
     resources :testimonials
-    resources :blog_posts do
+    resources :blog_posts, except: :show do
       member do
         get :preview
       end


### PR DESCRIPTION
This PR fixes the Admin UI to use the `button_to` helper rather than the `link_to` helper to enable items to be removed.