### PR TITLE
Remove redundant tags code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Below I explain the features of the application, its history, and some notes abo
 
 _Keith Pitty_
 
-_28 March, 2021_
+_15 April, 2021_
 
 ## Features
 
@@ -40,15 +40,13 @@ The admin UI provides me, when logged in, to:
 * view comments and remove those that have been caught as spam;
 * add images
 
-### Redundant features
+### Redundant feature
 
-The repository contains some redundant code for features that are no longer supported:
+The repository contains some redundant code for a feature that is no longer supported:
 
-* tags
 * an RSS feed
-* a page showing services I offered when I was freelancing
 
-One day I intend to clean these up. Perhaps I'll revive the RSS feed.
+One day I may revive it.
 
 ## History
 
@@ -147,5 +145,4 @@ Specs are supported by the `factory_bot_rails` gem.
 
 * fix broken RSS feed;
 * replace use of deprecated `paperclip` gem with `ActiveStorage`;
-* remove artifacts that are left over from features that are no longer supported;
 * improve usability of Admin UI by introducing React components

--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -49,7 +49,7 @@ module Admin
     private
 
     def blog_post_params
-      params.require(:blog_post).permit(:title, :post, :published, :comments_open, :tag_list)  
+      params.require(:blog_post).permit(:title, :post, :published, :comments_open)
     end
 
     def handle_create
@@ -77,7 +77,6 @@ module Admin
 
     def expire_fragment_caches
       expire_fragment "recent_posts"
-      expire_fragment "tag_cloud"
       expire_fragment "blog_post_in_list_#{@blog_post.id}"
       expire_fragment "blog_post_detail_#{@blog_post.id}"
     end

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -7,22 +7,7 @@ describe BlogPost do
                        title: params[:title],
                        post: params[:post],
                        published: true)
-    blog_post.tag_list.add(params[:tag_list], parse: true)
     blog_post.save
-  end
-
-  describe '.find_published_tagged_with' do
-    before do
-      create_blog_post(title: 'Post 1',
-                       post: 'test',
-                       tag_list: 'tag1')
-      create_blog_post(title: 'Post 2',
-                       post: 'test',
-                       tag_list: 'tag1, tag4')
-      create_blog_post(title: 'Post 3',
-                       post: 'test',
-                       tag_list: 'tag3')
-    end
   end
 
   describe '#set_param' do


### PR DESCRIPTION
The site no longer supports tags so let's remove the remaining remnants
of tag-related code.