### PR TITLE
Fix CC Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ _15 April, 2021_
 
 The repository makes use of Code Climate's Quality product, which shows that this codebase rates highly for maintainability and test coverage.
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/test_coverage)](https://codeclimate.com/github/codeclimate/codeclimate/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/f916b7da73b5f2c01e0f/maintainability)](https://codeclimate.com/github/keithpitty/kpdotcom/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/f916b7da73b5f2c01e0f/test_coverage)](https://codeclimate.com/github/keithpitty/kpdotcom/test_coverage)
 
 ## Features
 


### PR DESCRIPTION
I unwittingly added the wrong URLs within the Code Climate badges in the previous PR. This fixes the mistake.