### PR TITLE
Update README to reflect Rails update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository holds the codebase that supports [my website](https://keithpitty.com). It is written in Ruby on Rails, currently using version 6.1.3.1. 
+This repository holds the codebase that supports [my website](https://keithpitty.com). It is written in Ruby on Rails, currently using version 6.1.3.2.
 
 These days the application runs on Heroku using a Postgres database, MemCachier for caching, Papertrail for logging, and Twilio SendGrid for sending emails. I forget where I initially deployed it to back in 2007!
 
@@ -12,7 +12,7 @@ Below I explain the features of the application, its history, and some notes abo
 
 _Keith Pitty_
 
-_15 April, 2021_
+_9 May, 2021_
 
 ## Code Health
 


### PR DESCRIPTION
We have just merged a Dependabot PR to update Rails to 6.1.3.2 so we update the README to reflect this.