### PR TITLE
Set title within <head>

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'About me' } %>
 <h1>About me</h1>
 <div class="flex items-center px-6 py-4">
   <%= image_pack_tag("keith.jpg", :alt => "photo", class: "block mx-auto sm:mx-0 sm:flex-shrink-0 h-auto sm:h-24 rounded-full") %>

--- a/app/views/blog/archives/index.html.erb
+++ b/app/views/blog/archives/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'Archives' } %>
 <h1>Archives</h1>
 <ul>
   <% @blog_posts.each do |p| %>

--- a/app/views/blog/archives/show.html.erb
+++ b/app/views/blog/archives/show.html.erb
@@ -1,4 +1,5 @@
 <% cache "blog_post_detail_#{@blog_post.id}", skip_digest: true do %>
+  <% content_for(:title) { @blog_post.title } %>
   <h1 class="blog"><%= @blog_post.title %></h1>
   <h6><%= @blog_post.published_at.to_date.to_formatted_s(:full_australian) %></h6>
   <%= textilize(coderay(@blog_post.post)) %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'Contact me' } %>
 <h1>Contact me</h1>
 <p>
 Please complete the form below and I will endeavour to reply within 24 hours. That is, unless you are selling SEO services, in which case your message will be allowed through to the keeper, i.e. ignored.

--- a/app/views/testimonials/index.html.erb
+++ b/app/views/testimonials/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'Testimonials' } %>
 <h1>Testimonials</h1>
 <p>If you would like to talk with one of my referees, please <%= link_to 'contact me', '/contact'%>. Meanwhile, please read on to find out what others have had to say about my work.</p>
 <% cache "testimonials", skip_digest: true do %>


### PR DESCRIPTION
To provide Google Analytics with the opportunity to distinguish between
pages we need to make sure we set the title properly.